### PR TITLE
Update flags according to latest

### DIFF
--- a/lib/geth.js
+++ b/lib/geth.js
@@ -10,21 +10,21 @@ const geth = function(config){
     `--name 'geth-client' ` +
     `--rm ` +
     `${config.repo}:${config.tag} ` +
-    `--rpc ` +
-    `--rpcaddr '0.0.0.0' ` +
-    `--rpcport ${config.port} ` +
-    `--rpccorsdomain '*' ` +
+    `--http ` +
+    `--http.addr '0.0.0.0' ` +
+    `--http.port ${config.port} ` +
+    `--http.corsdomain '*' ` +
     `--ws ` +
-    `--wsport ${config.wsport} ` +
-    `--wsaddr '0.0.0.0' ` +
-    `--wsorigins '*' ` +
-    `--rpcapi personal,web3,eth,admin,debug,miner,txpool,net ` +
-    `--wsapi personal,web3,eth,admin,debug,miner,txpool,net ` +
+    `--ws.port ${config.wsport} ` +
+    `--ws.addr '0.0.0.0' ` +
+    `--ws.origins '*' ` +
+    `--http.api personal,web3,eth,admin,debug,miner,txpool,net ` +
+    `--ws.api personal,web3,eth,admin,debug,miner,txpool,net ` +
     `--nodiscover ` +
     `--allow-insecure-unlock ` +
     `--dev ` +
     `--dev.period ${config.period} ` +
-    `--targetgaslimit ${config.gasLimit} `
+    `--miner.gaslimit ${config.gasLimit} `
 }
 
 module.exports = geth;


### PR DESCRIPTION
Web3.js tests are currently failing because this version of `geth-dev-assistant` is using outdated flags